### PR TITLE
init: Allow the possibilty to use prebuilt ramdisk init

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -45,6 +45,7 @@ init_cflags += \
 
 # Do not build this even with mmma if we're system-as-root, otherwise it will overwrite the symlink.
 ifneq ($(BOARD_BUILD_SYSTEM_ROOT_IMAGE),true)
+ifneq ($(TARGET_USES_PREBUILT_RAMDISK_INIT),true)
 include $(CLEAR_VARS)
 LOCAL_CPPFLAGS := $(init_cflags)
 LOCAL_SRC_FILES := \
@@ -118,6 +119,7 @@ LOCAL_SANITIZE := signed-integer-overflow
 # First stage init is weird: it may start without stdout/stderr, and no /proc.
 LOCAL_NOSANITIZE := hwaddress
 include $(BUILD_EXECUTABLE)
+endif
 endif
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
- Oppo and Realme devices who use ColorOS 11 or RealmeUI V2.0 as base need stock ROM ramdisk init for allow device to boot normally (device will immediatly boot to bootloader otherwise due to missing ramdisk init changes)
- This flag allow to use prebuilt ramdisk init without trigerring duplicated rules

Change-Id: Ic8a57cd08178c9bc4e22b10bfd4e22bd9b9aa43e
Signed-off-by: TheMalachite <eliasgheeraert@gmail.com>